### PR TITLE
Feat/#8/로깅 + api요청 코드

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -392,7 +392,18 @@ files = [
     {file = "uritemplate-4.1.1.tar.gz", hash = "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0"},
 ]
 
+[[package]]
+name = "xmltodict"
+version = "0.13.0"
+description = "Makes working with XML feel like you are working with JSON"
+optional = false
+python-versions = ">=3.4"
+files = [
+    {file = "xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"},
+    {file = "xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56"},
+]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "591ef9e5cd9cf9b30c4ef102ce8702c6d6e5aec6b99e969256efe1eea336a01d"
+content-hash = "2457feea715b0f89635e91d2736f0ff6455121609223151ed34f530bc77e2482"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ pillow = "^10.1.0"
 drf-yasg = "^1.21.7"
 gunicorn = "^21.2.0"
 pymysql = "^1.1.0"
-mysqlclient = "^2.2.0"
+mysqlclient = "2.2.0"
+xmltodict = "^0.13.0"
 
 
 [build-system]

--- a/utils/custom_logger.py
+++ b/utils/custom_logger.py
@@ -1,0 +1,43 @@
+import logging
+
+'''
+< LOG LEVELS >
+DEBUG: 프로그램 작동에 대한 상세한 정보를 가지는 로그. 문제의 원인을 파악할 때에만 이용.
+INFO: 프로그램 작동이 예상대로 진행되고 있는지 트래킹하기 위해 사용.
+WARNING: 예상치 못한 일이나 추후 발생 가능한 문제를 표시하기 위함.
+ERROR: 심각한 문제로 인해 프로그램이 의도한 기능을 수행하지 못하고 있는 상황을 표시.
+CRITICAL: 더욱 심각한 문제로 인해 프로그램 실행 자체가 언제라도 중단될 수 있음을 표시.
+'''
+
+class CustomLogger:
+    
+    def __init__(self, level="WARNING"):
+        '''
+        level : 로그확인할 단계 선택 (DEBUG < INFO < WARNING < ERROR < CRITICAL)
+        '''
+        self.level = level
+    
+    def get_logger(self):
+        # logger
+        logger = logging.getLogger("log")
+        
+        # Check handler exists
+        if len(logger.handlers) > 0:
+            return logger # Logger already exists
+        
+        logger_level = getattr(logging, self.level.upper(), "INFO")
+        
+        if not isinstance(logger_level, int):
+            raise ValueError(f"Invalid log level: {self.level}")
+        
+        logger.setLevel(logger_level)
+        
+        handler = logging.StreamHandler()
+
+        formatter = logging.Formatter('%(asctime)s|%(name)s|%(levelname)s:%(message)s')
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+        logger.info("server start!")
+        
+        return logger

--- a/utils/get_data.py
+++ b/utils/get_data.py
@@ -124,8 +124,9 @@ try:
                     page_index += 1
                     new_data.append(get_mapping_data(raw_data[API_URL[key].split('/')[-1]]['row'], DB_FIELD)) #? 데이터 매핑
             except Exception as e:
-                logging.error(f'API 요청 실패 --- {status}\n {e}')
+                logging.error(f'API 요청 실패 --- {raw_data}\n {e}')
                 logging.info(f'time_check: {time.time()-start_time2}')
+                raise Exception('API 요청 실패 : 에러 코드를  확인하세요')
                 # status = raw_data['RESULT']['CODE']   #* 에러코드 반환시 형식
                 # status_code = status.split('-')[-1]
                 # if status_code != '000' :

--- a/utils/get_data.py
+++ b/utils/get_data.py
@@ -1,0 +1,142 @@
+import time
+import json
+import requests
+import environ
+import xmltodict
+from custom_logger import CustomLogger
+
+logging = CustomLogger("DEBUG").get_logger()  # 테스트용 추후변경
+
+env = environ.Env(DEBUG=(bool, True))
+
+DB_FIELD = {   # DB 필드명 매핑용
+  'SIGUN_NM'                    :       'sgg'                  
+  ,'SIGUN_CD'                   :       'sgg_code'             
+  ,'BIZPLC_NM'                  :       'name'                 
+  ,'LICENSG_DE'                 :       'start_date'           
+  ,'BSN_STATE_NM'               :       'business_state'       
+  ,'CLSBIZ_DE'                  :       'closed_date'           
+  ,'LOCPLC_AR'                  :       'local_area'       
+  ,'GRAD_FACLT_DIV_NM'          :       'water_facility'    
+  ,'MALE_ENFLPSN_CNT'           :       'male_employee_cnt'    
+  ,'YY'                         :       'year'                 
+  ,'MULTI_USE_BIZESTBL_YN'      :       'multi_used'           
+  ,'GRAD_DIV_NM'                :       'grade_sep'            
+  ,'TOT_FACLT_SCALE'            :       'total_area'           
+  ,'FEMALE_ENFLPSN_CNT'         :       'female_employee_cnt'  
+  ,'BSNSITE_CIRCUMFR_DIV_NM'    :       'buisiness_site'       
+  ,'SANITTN_INDUTYPE_NM'        :       'sanitarity'           
+  ,'SANITTN_BIZCOND_NM'         :       'food_category'        
+  ,'TOT_EMPLY_CNT'              :       'employee_cnt'         
+  ,'REFINE_LOTNO_ADDR'          :       'address_lotno'        
+  ,'REFINE_ROADNM_ADDR'         :       'address_roadnm'       
+  ,'REFINE_ZIP_CD'              :       'zip_code'             
+  ,'REFINE_WGS84_LOGT'          :       'logitude'             
+  ,'REFINE_WGS84_LAT'           :       'latitude'             
+     
+}
+
+API_URL = {
+    "LUNCH" : "https://openapi.gg.go.kr/Genrestrtlunch", # 깁밥
+    "JPTFOOD" : "https://openapi.gg.go.kr/Genrestrtjpnfood", # 일식
+    "CHIFOOD" : "https://openapi.gg.go.kr/Genrestrtchifood", # 중식
+    "FASTFOOD" : "https://openapi.gg.go.kr/Genrestrtfastfood", # 패스트푸드
+}
+
+API_KEY= env('API_KEY') 
+
+
+def get_restaurant(api_url, api_key, page_index:int, page_size:int)->dict:   # API 요청 
+    '''
+    :param api_url: 요청할 api 주소
+    :param api_key: api 인증 키
+    :param page_index: 페이지 번호
+    :param page_size:  한 페이지에 담길 데이터의 양
+    :return: dict 형식의 데이터 
+    '''
+    # API 요청을 위한 파라미터 설정
+    params = {
+        "Key": api_key,
+        "pIndex" : page_index,
+        "pSize": str(page_size),
+    }
+
+    # API 요청 보내기
+    response = requests.get(api_url, params=params)
+
+
+    if response.status_code == 200:
+        root = response.text
+        jsondata = json.dumps(xmltodict.parse(root), indent=4)
+        
+        dict = json.loads(jsondata)
+        # logging.debug("dict: ", dict)
+        
+
+    return dict
+
+
+def get_mapping_data(raw_data:dict, field:dict) -> dict:
+    '''
+    :param raw_data:  원본데이터
+    :param field:  기존필드명, 변경할 필드명이 담긴 dict
+    :return: 매핑된 데이터 
+    '''
+    result = {}
+    if len(raw_data) != 1:
+    # 기존 데이터의 키를 DB_FIELD 딕셔너리를 참조하여 교체
+        for el in raw_data:
+            for key, value in el.items():
+                new_key = field[key]  
+                result[new_key] = value
+    else: 
+        for key, value in raw_data.items():
+            new_key = field[key]  
+            result[new_key] = value
+
+    return result
+
+
+try:
+    start_time1 = time.time()
+    new_data = [] #결과 데이터
+     
+    for key in API_URL.keys(): # 모든 url에 요청
+        start_time2 = time.time()
+        unprocessed_data = -1 #전체 데이터 숫자 확인용
+        #* 아래 두 변수는 필요에 따라 수정하여 사용합니다.
+        page_index = 1  # 페이지 번호
+        page_size = 1000  # 페이지에 담긴 정보 수 
+        
+        logging.info(f'----------{key} : {API_URL[key]} API 요청 시작----------')
+        
+        while unprocessed_data > 0 or unprocessed_data == -1:
+            raw_data = get_restaurant(API_URL[key], API_KEY, page_index,  page_size)  #? API 요청
+            try:
+                status = raw_data[API_URL[key].split('/')[-1]]['head']['RESULT']['CODE'] #* CODE:INFO-000시 정상, 그 외 API 요청 실패처리 
+                status_code = status.split('-')[-1]
+                if status_code == '000' :   # 요청 성공
+                    tot_cnt = int(raw_data[API_URL[key].split('/')[-1]]['head']['list_total_count'])
+                    unprocessed_data =  tot_cnt
+                    unprocessed_data -= page_size*page_index
+                    unprocessed_data = max(unprocessed_data, 0)
+                    logging.debug(f'남은 데이터 수 : {unprocessed_data}')
+                    page_index += 1
+                    new_data.append(get_mapping_data(raw_data[API_URL[key].split('/')[-1]]['row'], DB_FIELD)) #? 데이터 매핑
+            except Exception as e:
+                logging.error(f'API 요청 실패 --- {status}\n {e}')
+                logging.info(f'time_check: {time.time()-start_time2}')
+                # status = raw_data['RESULT']['CODE']   #* 에러코드 반환시 형식
+                # status_code = status.split('-')[-1]
+                # if status_code != '000' :
+            # if page_index == 5:   #! 테스트용 제한
+        logging.debug(f'new_data : {new_data}  리스트 길이 :  {len(new_data)}, 전체 데이터 수 : {tot_cnt}')
+        logging.info(f'{key}_time_check: {time.time()-start_time2}')
+        logging.debug('==========*****==========\n')
+    logging.debug(f'new_data : {new_data}  리스트 길이 :  {len(new_data)}, 전체 데이터 수 : {tot_cnt}')
+    logging.info(f'total_time_check: {time.time()-start_time1}')
+
+except Exception as e:
+        logging.info(f'{key}_time_check: {time.time()-start_time2}')
+        logging.error(f'ERROR : {e}')    
+

--- a/utils/get_data.py
+++ b/utils/get_data.py
@@ -70,7 +70,7 @@ def get_restaurant(api_url, api_key, page_index:int, page_size:int)->dict:   # A
         jsondata = json.dumps(xmltodict.parse(root), indent=4)
         
         dict = json.loads(jsondata)
-        # logging.debug("dict: ", dict)
+        # logging.debug(f"dict: {dict}")
         
 
     return dict
@@ -103,7 +103,7 @@ try:
      
     for key in API_URL.keys(): # 모든 url에 요청
         start_time2 = time.time()
-        unprocessed_data = -1 #전체 데이터 숫자 확인용
+        unprocessed_data = -1 #남은 데이터 숫자 확인용
         #* 아래 두 변수는 필요에 따라 수정하여 사용합니다.
         page_index = 1  # 페이지 번호
         page_size = 1000  # 페이지에 담긴 정보 수 

--- a/utils/get_data.py
+++ b/utils/get_data.py
@@ -58,7 +58,7 @@ def get_restaurant(api_url, api_key, page_index:int, page_size:int)->dict:   # A
     params = {
         "Key": api_key,
         "pIndex" : page_index,
-        "pSize": str(page_size),
+        "pSize": page_size,
     }
 
     # API 요청 보내기


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/tneoeo2/#8-> dev

### 변경 사항
- 로깅코드 추가 
- xmltodict poetry에 추가
- api 요청코드 추가 
>-  데이터를 나누어 요청하여 추후 데이터의 양이 많아졌을때 네트워크 부하를 줄이고
중간에 요청 실패시, 해당부분부터 이어요청할 수 있게 구성하였습니다
> - api요청 실패시 200응답이 반환 후, 해당 api의 에러코드를 반환하는 특성에 맞춰 예외처리
[OPENAPI-메시지 설명 참고](https://data.gg.go.kr/portal/data/service/selectServicePage.do?page=1&rows=10&sortColumn=&sortDirection=&infId=0WL0HABQXJPCHAM9SJT813545051&infSeq=3)
